### PR TITLE
controllo di presenza del codiceIpa in query string

### DIFF
--- a/src/app/core/company/company-graph.component.ts
+++ b/src/app/core/company/company-graph.component.ts
@@ -180,6 +180,9 @@ export class CompanyGraphComponent implements OnInit, OnDestroy, OnChanges{
     });
     this.route.queryParams.subscribe((queryParams: Params) => {
       this.codiceIpa = queryParams.codiceIpa;
+	  if (!this.codiceIpa && this.company) {
+        this.codiceIpa = this.company.codiceIpa;
+      }
       this.fromMap = queryParams.fromMap;
       this.zoom = queryParams.zoom;
       this.paramsWorkflowId = queryParams.workflowId;


### PR DESCRIPTION
Modifica per eliminare un errore che si presenta nella navigazione dell'interfaccia pubblica quando si clicca su 'regole' e si proviene dalla company search.