### PR TITLE
fix(company-graph): default to last completed scan for admin detail

### DIFF
--- a/src/app/core/company/company-graph.component.ts
+++ b/src/app/core/company/company-graph.component.ts
@@ -193,6 +193,7 @@ export class CompanyGraphComponent implements OnInit, OnDestroy, OnChanges{
           this.company = company[0];
           this.tabRuleActive = true;
           this.tabPAActive = false;
+          this.tabFailedActive = false;
           if (!this.company) {
             this.apiMessageService.sendMessage(MessageType.ERROR,  `PA non presente!`);
           }
@@ -206,6 +207,11 @@ export class CompanyGraphComponent implements OnInit, OnDestroy, OnChanges{
             this.conductorService.getAll({
               includeClosed: true,
               includeTasks: false
+            }).subscribe((workflows: Workflow[]) => {
+              this.optionsWorkflow = [];
+              this.conductorService.getAll({
+                includeClosed: true,
+                includeTasks: false
               },`/${ConductorService.AMMINISTRAZIONE_TRASPARENTE_FLOW}/correlated/${this.codiceIpa}`).subscribe((ipaWorkflows: Workflow[]) => {
                 ipaWorkflows.concat(workflows).sort((a,b) => (a.startTime < b.startTime)? 1 : -1).forEach((workflow: Workflow) => {
                   this.optionsWorkflow.push({
@@ -223,7 +229,10 @@ export class CompanyGraphComponent implements OnInit, OnDestroy, OnChanges{
             });
           });          
         } else {
-          this.manageChart();
+          this.getWorkflow(queryParams).subscribe((workflowId: string | undefined) => {
+            this.filterFormSearch.controls.workflowId.patchValue(workflowId);
+            this.manageChart(workflowId);
+          });
         }
       } else {
         this.configurationService.getAll().subscribe((configurations: Configuration[]) => {


### PR DESCRIPTION
## Contesto
Nella pagina dettaglio amministrazione (`#/company-graph?codiceIpa=...`) veniva selezionata automaticamente l’ultima scansione disponibile, includendo anche workflow ancora in esecuzione.

## Modifica
Aggiornata la logica di default in `company-graph`:
- se `workflowId` è presente in querystring, resta prioritario;
- se `workflowId` non è presente, viene selezionata **l’ultima scansione completata** (`COMPLETED`) e non una scansione `RUNNING`.

## File modificato
- `src/app/core/company/company-graph.component.ts`

## Impatto atteso
Aprendo il dettaglio di una PA senza specificare `workflowId`, l’utente vede i risultati dell’ultima scansione terminata, evitando dati parziali dovuti a esecuzioni in corso.

## Verifica
- Build frontend eseguita con successo (`npm run build`).
- Verifica funzionale:
  - apertura `#/company-graph?codiceIpa=<ipa>` senza `workflowId`;
  - selezione automatica di workflow completato;
  - assenza di selezione di workflow in stato `RUNNING`.
